### PR TITLE
Do not run the add color command if the color scheme is already installed

### DIFF
--- a/manifests/colors.pp
+++ b/manifests/colors.pp
@@ -57,5 +57,6 @@ define iterm2::colors (
 ) {
   exec { $name:
     command => join(split(template('iterm2/colors.erb'), '\n'), ' '),
+    unless => "/usr/libexec/PlistBuddy -c \"print :'Custom Color Presets':'${name}'\" ~/Library/Preferences/com.googlecode.iterm2.plist",
   }
 }


### PR DESCRIPTION
I was annoyed with the notice always showing up every time I run boxen, so I added a check to not run the command if the color scheme is already present.

I'm not completely comfortable with the hardcoded plist file, but Plistbuddy only accepts a plist path and I did not find a command to output the plist path from `defaults -app iTerm` or other command.

Hopefully this looks good, otherwise please suggest any improvements!
