### PR TITLE
Parameterize iterm2::dev and bump the default version

### DIFF
--- a/manifests/dev.pp
+++ b/manifests/dev.pp
@@ -3,9 +3,12 @@
 # Usage:
 #
 #   include iterm2::dev
-class iterm2::dev {
-  package { 'iTerm2-1_0_0_20140112':
-    source   => 'http://www.iterm2.com/downloads/beta/iTerm2-1_0_0_20140112.zip',
+#   class { 'iterm2::dev':
+#     version => '20140112'
+#   }
+class iterm2::dev($version = "20140403") {
+  package { "iTerm2-1_0_0_${version}":
+    source   => "http://www.iterm2.com/downloads/beta/iTerm2-1_0_0_${version}.zip",
     provider => 'compressed_app'
   }
 }

--- a/spec/classes/iterm2_dev_spec.rb
+++ b/spec/classes/iterm2_dev_spec.rb
@@ -2,8 +2,9 @@ require 'spec_helper'
 
 describe 'iterm2::dev' do
   it do
-    should contain_package('iTerm2-1_0_0_20140112').with({
-      :source   => 'http://www.iterm2.com/downloads/beta/iTerm2-1_0_0_20140112.zip',
+    version = '20140403'
+    should contain_package("iTerm2-1_0_0_#{version}").with({
+      :source   => "http://www.iterm2.com/downloads/beta/iTerm2-1_0_0_#{version}.zip",
       :provider => 'compressed_app'
     })
   end


### PR DESCRIPTION
Updated the code to the latest version recommended by the iTerm 2 website.

The good thing about this is the next time users want to update the beta version, they can do it with simply changing their own code, without forking the project.
