### PR TITLE
Comply to the Puppet lint standards

### DIFF
--- a/manifests/dev.pp
+++ b/manifests/dev.pp
@@ -6,7 +6,7 @@
 #   class { 'iterm2::dev':
 #     version => '20140112'
 #   }
-class iterm2::dev($version = "20140403") {
+class iterm2::dev($version = '20140403') {
   package { "iTerm2-1_0_0_${version}":
     source   => "http://www.iterm2.com/downloads/beta/iTerm2-1_0_0_${version}.zip",
     provider => 'compressed_app'


### PR DESCRIPTION
The latest [travis build](https://travis-ci.org/boxen/puppet-iterm2/builds/22983946) went on with green tests, but the linter failed it, as I had a double quoted string with no interpolation in it.
