### PR TITLE
Add support for iTerm2 2.1 beta release

### DIFF
--- a/manifests/dev.pp
+++ b/manifests/dev.pp
@@ -9,9 +9,14 @@
 #   class { 'iterm2::dev':
 #     version => '20140421'
 #   }
-class iterm2::dev($version = '20141103') {
+class iterm2::dev($major = '2_0_0', $version = '20150412') {
+  $join = ''
+  if ($version != '') and ($major != '') {
+    $join = '_'
+  }
+  
   package { 'iTerm':
-    source   => "https://iterm2.com/downloads/beta/iTerm2-2_0_0_${version}.zip",
+    source   => "https://iterm2.com/downloads/beta/iTerm2-${major}${join}${version}.zip",
     provider => 'compressed_app'
   }
 }

--- a/manifests/dev.pp
+++ b/manifests/dev.pp
@@ -10,11 +10,12 @@
 #     version => '20140421'
 #   }
 class iterm2::dev($major = '2_0_0', $version = '20150412') {
-  $join = ''
   if ($version != '') and ($major != '') {
     $join = '_'
+  } else {
+    $join = ''
   }
-  
+
   package { 'iTerm':
     source   => "https://iterm2.com/downloads/beta/iTerm2-${major}${join}${version}.zip",
     provider => 'compressed_app'

--- a/spec/classes/iterm2_dev_spec.rb
+++ b/spec/classes/iterm2_dev_spec.rb
@@ -3,7 +3,6 @@ require 'spec_helper'
 
 describe "iterm2::dev" do
   version = '20141103'
-  let(:facts) { default_test_facts }
   let(:params) {
     {
       :version => "#{version}"
@@ -22,7 +21,6 @@ end
 describe "iterm2::dev" do
   version = ''
   major = '2_1'
-  let(:facts) { default_test_facts }
   let(:params) {
     {
       :version => "#{version}",

--- a/spec/classes/iterm2_dev_spec.rb
+++ b/spec/classes/iterm2_dev_spec.rb
@@ -1,10 +1,38 @@
 require 'spec_helper'
 
-describe 'iterm2::dev' do
+
+describe "iterm2::dev" do
+  version = '20141103'
+  let(:facts) { default_test_facts }
+  let(:params) {
+    {
+      :version => "#{version}"
+    }
+  }
+
   it do
-    version = '20141103'
     should contain_package("iTerm").with({
       :source   => "https://iterm2.com/downloads/beta/iTerm2-2_0_0_#{version}.zip",
+      :provider => 'compressed_app'
+    })
+  end
+end
+
+
+describe "iterm2::dev" do
+  version = ''
+  major = '2_1'
+  let(:facts) { default_test_facts }
+  let(:params) {
+    {
+      :version => "#{version}",
+      :major => "#{major}"
+    }
+  }
+
+  it do
+    should contain_package("iTerm").with({
+      :source   => "https://iterm2.com/downloads/beta/iTerm2-#{major}.zip",
       :provider => 'compressed_app'
     })
   end


### PR DESCRIPTION
I've modified dev.pp and the corresponding spec to add support for the new 2.1 beta.  