### PR TITLE
Remove prefix 'v' from version name

### DIFF
--- a/manifests/stable.pp
+++ b/manifests/stable.pp
@@ -12,12 +12,12 @@
 #
 class iterm2::stable (
   $ensure  = 'present',
-  $version ='2_0'
+  $version ='v2_1_1'
 ) {
   package { 'iTerm':
     ensure   => $ensure,
     flavor   => 'zip',
     provider => 'compressed_app',
-    source   => "http://www.iterm2.com/downloads/stable/iTerm2_v${version}.zip"
+    source   => "http://www.iterm2.com/downloads/stable/iTerm2_${version}.zip"
   }
 }

--- a/manifests/stable.pp
+++ b/manifests/stable.pp
@@ -12,12 +12,12 @@
 #
 class iterm2::stable (
   $ensure  = 'present',
-  $version ='v2_1_1'
+  $version ='2_1_1'
 ) {
   package { 'iTerm':
     ensure   => $ensure,
     flavor   => 'zip',
     provider => 'compressed_app',
-    source   => "http://www.iterm2.com/downloads/stable/iTerm2_${version}.zip"
+    source   => "http://www.iterm2.com/downloads/stable/iTerm2-${version}.zip"
   }
 }

--- a/spec/classes/iterm2_stable_spec.rb
+++ b/spec/classes/iterm2_stable_spec.rb
@@ -2,12 +2,12 @@ require 'spec_helper'
 
 describe 'iterm2::stable' do
   it do
-    version = '2_0'
+    version = 'v2_0'
     should contain_package('iTerm').with({
       :ensure   => 'present',
       :flavor   => 'zip',
       :provider => 'compressed_app',
-      :source   => "http://www.iterm2.com/downloads/stable/iTerm2_v#{version}.zip"
+      :source   => "http://www.iterm2.com/downloads/stable/iTerm2_#{version}.zip"
     })
   end
 end

--- a/spec/classes/iterm2_stable_spec.rb
+++ b/spec/classes/iterm2_stable_spec.rb
@@ -3,17 +3,17 @@ require 'spec_helper'
 describe 'iterm2::stable' do
   let(:params) do
     {
-      :version => 'v2_0'
+      :version => '2_1_1'
     }
   end
 
   it do
-    version = 'v2_0'
+    version = '2_1_1'
     should contain_package('iTerm').with({
       :ensure   => 'present',
       :flavor   => 'zip',
       :provider => 'compressed_app',
-      :source   => "http://www.iterm2.com/downloads/stable/iTerm2_#{version}.zip"
+      :source   => "http://www.iterm2.com/downloads/stable/iTerm2-#{version}.zip"
     })
   end
 end

--- a/spec/classes/iterm2_stable_spec.rb
+++ b/spec/classes/iterm2_stable_spec.rb
@@ -3,6 +3,11 @@ require 'spec_helper'
 describe 'iterm2::stable' do
   it do
     version = 'v2_0'
+    let(:params) do
+      {
+        :version => 'v2_0'
+      }
+    end
     should contain_package('iTerm').with({
       :ensure   => 'present',
       :flavor   => 'zip',

--- a/spec/classes/iterm2_stable_spec.rb
+++ b/spec/classes/iterm2_stable_spec.rb
@@ -1,13 +1,14 @@
 require 'spec_helper'
 
 describe 'iterm2::stable' do
+  let(:params) do
+    {
+      :version => 'v2_0'
+    }
+  end
+
   it do
     version = 'v2_0'
-    let(:params) do
-      {
-        :version => 'v2_0'
-      }
-    end
     should contain_package('iTerm').with({
       :ensure   => 'present',
       :flavor   => 'zip',


### PR DESCRIPTION
At least to support stable release version 2_1_1 of  iTerm2.
This allow specifiying version name in hiera.